### PR TITLE
Slayer: Fix infobox expiry ignored until first combat

### DIFF
--- a/slayer/slayer.gradle.kts
+++ b/slayer/slayer.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.9"
+version = "0.0.10"
 
 project.extra["PluginName"] = "Slayer"
 project.extra["PluginDescription"] = "Show additional slayer task related information"

--- a/slayer/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
+++ b/slayer/src/main/java/net/runelite/client/plugins/slayer/SlayerPlugin.java
@@ -578,9 +578,17 @@ public class SlayerPlugin extends Plugin
 			}
 			forcedWait--;
 		}
+		
 
-		if (infoTimer != null && config.statTimeout() != 0)
+		// If a timeout is configured for showing slayer stats
+		if (config.statTimeout() != 0)
 		{
+			// If the timer has not started, start it now
+			if (infoTimer == null)
+			{
+				infoTimer = Instant.now();
+			}
+			
 			Duration timeSinceInfobox = Duration.between(infoTimer, Instant.now());
 			Duration statTimeout = Duration.ofMinutes(config.statTimeout());
 


### PR DESCRIPTION
If the Slayer plugin's Task InfoBox is enabled and TaskInfoBox Expiry is set, the timer for the expiration is not started until killing the first slayer monster. This means that if you are doing something other than slayer after a login you have to uncheck TaskInfoBox to get rid of it.

This PR makes it so if a timeout is set, it will always be adhered to.