### PR TITLE
raids:itemrecommendation

### DIFF
--- a/raids/raids.gradle.kts
+++ b/raids/raids.gradle.kts
@@ -24,7 +24,6 @@ import ProjectVersions.rlVersion
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 version = "0.0.7"
 
 project.extra["PluginName"] = "CoX Scouter"

--- a/raids/raids.gradle.kts
+++ b/raids/raids.gradle.kts
@@ -24,6 +24,7 @@ import ProjectVersions.rlVersion
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 version = "0.0.7"
 
 project.extra["PluginName"] = "CoX Scouter"

--- a/raids/raids.gradle.kts
+++ b/raids/raids.gradle.kts
@@ -31,6 +31,7 @@ project.extra["PluginName"] = "CoX Scouter"
 project.extra["PluginDescription"] = "Show helpful information for the Chambers of Xeric raid"
 
 dependencies {
+    
     annotationProcessor(Libraries.lombok)
     annotationProcessor(Libraries.pf4j)
 

--- a/raids/raids.gradle.kts
+++ b/raids/raids.gradle.kts
@@ -25,7 +25,7 @@ import ProjectVersions.rlVersion
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.6"
+version = "0.0.7"
 
 project.extra["PluginName"] = "CoX Scouter"
 project.extra["PluginDescription"] = "Show helpful information for the Chambers of Xeric raid"

--- a/raids/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/raids/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018, Kamiel
  * Copyright (c) 2019, ganom <https://github.com/Ganom>
+ * Copyright (c) 2020, Crystalknoct
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -179,7 +180,7 @@ public interface RaidsConfig extends Config
 	)
 	default String recommendedItems()
 	{
-		return "[muttadiles,zamorak godsword],[Vasa,ghrazi rapier],[Guardians,Dragon pickaxe],[Mystics,Salve amulet(ei)],[Shamans,Antidote++],[Vespula,Super restore(4)]";
+		return "[Muttadiles, zamorak godsword, ice barrage],[Vasa,zamorakian hasta, abyssal dagger, ghrazi rapier, vengeance],[Guardians,Dragon pickaxe],[Mystics,Salve amulet(ei)],[Shamans,Sanfew serum(4), Antidote++(4)],[Vespula,Prayer potion(4), Super restore(4), Sanfew Serum(4)],[Tekton,Elder Maul, Abyssal Bludgeon, Vengeance],[Thieving,lockpick]";
 	}
 
 	@ConfigItem(

--- a/raids/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/raids/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -24,7 +24,6 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 package net.runelite.client.plugins.raids;
 
 import java.awt.Color;

--- a/raids/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/raids/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -180,7 +180,7 @@ public interface RaidsConfig extends Config
 	)
 	default String recommendedItems()
 	{
-		return "[Muttadiles, zamorak godsword, ice barrage],[Vasa,zamorakian hasta, abyssal dagger, ghrazi rapier, vengeance],[Guardians,Dragon pickaxe],[Mystics,Salve amulet(ei)],[Shamans,Sanfew serum(4), Antidote++(4)],[Vespula,Prayer potion(4), Super restore(4), Sanfew Serum(4)],[Tekton,Elder Maul, Abyssal Bludgeon, Vengeance],[Thieving,lockpick]";
+		return "[Muttadiles, zamorak godsword, ice barrage],[Vasa,zamorakian hasta, abyssal dagger, Blade of saeldor, ghrazi rapier, vengeance],[Guardians,Dragon pickaxe],[Mystics,Salve amulet(ei)],[Shamans,Sanfew serum(4), Antidote++(4)],[Vespula,Prayer potion(4), Super restore(4), Sanfew Serum(4)],[Tekton,Elder Maul, Abyssal Bludgeon, Vengeance],[Thieving,lockpick],[Ice Demon, fire surge]";
 	}
 
 	@ConfigItem(

--- a/raids/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/raids/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -24,6 +24,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 package net.runelite.client.plugins.raids;
 
 import java.awt.Color;

--- a/raids/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
+++ b/raids/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
@@ -473,7 +473,7 @@ public class RaidsOverlay extends Overlay
 	{
 		BufferedImage bim;
 		{
-			if (!(id == SpriteID.SPELL_ICE_BARRAGE || id == SpriteID.SPELL_VENGEANCE))
+			if (!(id == SpriteID.SPELL_ICE_BARRAGE || id == SpriteID.SPELL_VENGEANCE || id == SpriteID.SPELL_FIRE_SURGE))
 			{
 				bim = itemManager.getImage(id);
 			}
@@ -489,7 +489,7 @@ public class RaidsOverlay extends Overlay
 			{
 				return ImageUtil.resizeCanvas(bim, ICON_SIZE, ICON_SIZE);
 			}
-			if (!(id == SpriteID.SPELL_ICE_BARRAGE || id == SpriteID.SPELL_VENGEANCE))
+			if (!(id == SpriteID.SPELL_ICE_BARRAGE || id == SpriteID.SPELL_VENGEANCE || id == SpriteID.SPELL_FIRE_SURGE))
 			{
 				return ImageUtil.resizeImage(bim, SMALL_ICON_SIZE, SMALL_ICON_SIZE);
 			}

--- a/raids/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
+++ b/raids/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018, Kamiel
  * Copyright (c) 2019, ganom <https://github.com/Ganom>
+ * Copyright (c) 2020, Crystalknoct
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -41,12 +42,12 @@ import lombok.Setter;
 import net.runelite.api.Client;
 import static net.runelite.api.MenuOpcode.RUNELITE_OVERLAY;
 import static net.runelite.api.MenuOpcode.RUNELITE_OVERLAY_CONFIG;
-import net.runelite.client.game.WorldService;
 import net.runelite.api.SpriteID;
 import net.runelite.api.util.Text;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.SpriteManager;
+import net.runelite.client.game.WorldService;
 import net.runelite.client.plugins.raids.solver.Room;
 import net.runelite.client.ui.overlay.Overlay;
 import static net.runelite.client.ui.overlay.OverlayManager.OPTION_CONFIGURE;
@@ -69,10 +70,10 @@ import net.runelite.http.api.worlds.WorldResult;
 @Singleton
 public class RaidsOverlay extends Overlay
 {
-	
+
 	@Inject
 	private WorldService worldService;
-	
+
 	private static final int OLM_PLANE = 0;
 	private static final int BORDER_OFFSET = 2;
 	private static final int ICON_SIZE = 32;
@@ -295,7 +296,7 @@ public class RaidsOverlay extends Overlay
 				clanOwner = "Open CC Tab";
 				color = Color.RED;
 			}
-			
+
 			String worldString = "W" + client.getWorld();
 			WorldResult worldResult = worldService.getWorlds();
 			if (worldResult != null)
@@ -471,26 +472,28 @@ public class RaidsOverlay extends Overlay
 	private BufferedImage getImage(int id, boolean small)
 	{
 		BufferedImage bim;
-		if (id != SpriteID.SPELL_ICE_BARRAGE)
 		{
-			bim = itemManager.getImage(id);
+			if (!(id == SpriteID.SPELL_ICE_BARRAGE || id == SpriteID.SPELL_VENGEANCE))
+			{
+				bim = itemManager.getImage(id);
+			}
+			else
+			{
+				bim = spriteManager.getSprite(id, 0);
+			}
+			if (bim == null)
+			{
+				return null;
+			}
+			if (!small)
+			{
+				return ImageUtil.resizeCanvas(bim, ICON_SIZE, ICON_SIZE);
+			}
+			if (!(id == SpriteID.SPELL_ICE_BARRAGE || id == SpriteID.SPELL_VENGEANCE))
+			{
+				return ImageUtil.resizeImage(bim, SMALL_ICON_SIZE, SMALL_ICON_SIZE);
+			}
+			return ImageUtil.resizeCanvas(bim, SMALL_ICON_SIZE, SMALL_ICON_SIZE);
 		}
-		else
-		{
-			bim = spriteManager.getSprite(id, 0);
-		}
-		if (bim == null)
-		{
-			return null;
-		}
-		if (!small)
-		{
-			return ImageUtil.resizeCanvas(bim, ICON_SIZE, ICON_SIZE);
-		}
-		if (id != SpriteID.SPELL_ICE_BARRAGE)
-		{
-			return ImageUtil.resizeImage(bim, SMALL_ICON_SIZE, SMALL_ICON_SIZE);
-		}
-		return ImageUtil.resizeCanvas(bim, SMALL_ICON_SIZE, SMALL_ICON_SIZE);
 	}
 }

--- a/raids/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
+++ b/raids/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
@@ -24,7 +24,6 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 package net.runelite.client.plugins.raids;
 
 import java.awt.Color;

--- a/raids/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
+++ b/raids/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
@@ -24,6 +24,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 package net.runelite.client.plugins.raids;
 
 import java.awt.Color;

--- a/raids/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/raids/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -915,6 +915,10 @@ public class RaidsPlugin extends Plugin
 				{
 					map.get(key).add(SpriteID.SPELL_VENGEANCE);
 				}
+				if (itemName.equals("fire surge"))
+				{
+					map.get(key).add(SpriteID.SPELL_FIRE_SURGE);
+				}
 				else if (itemName.startsWith("salve"))
 				{
 					map.get(key).add(ItemID.SALVE_AMULETEI);

--- a/raids/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/raids/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -24,6 +24,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 package net.runelite.client.plugins.raids;
 
 import com.google.common.base.Joiner;

--- a/raids/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/raids/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -24,7 +24,6 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 package net.runelite.client.plugins.raids;
 
 import com.google.common.base.Joiner;

--- a/raids/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/raids/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018, Kamiel
  * Copyright (c) 2019, ganom <https://github.com/Ganom>
+ * Copyright (c) 2020, Crystalknoct
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -421,7 +422,7 @@ public class RaidsPlugin extends Plugin
 	@Subscribe
 	private void onConfigChanged(ConfigChanged event)
 	{
-		if (!event.getGroup().equals("raids"))
+		if (!event.getGroup().equals("net/runelite/client/plugins/raids"))
 		{
 			return;
 		}
@@ -909,6 +910,10 @@ public class RaidsPlugin extends Plugin
 				if (itemName.equals("ice barrage"))
 				{
 					map.get(key).add(SpriteID.SPELL_ICE_BARRAGE);
+				}
+				if (itemName.equals("vengeance"))
+				{
+					map.get(key).add(SpriteID.SPELL_VENGEANCE);
 				}
 				else if (itemName.startsWith("salve"))
 				{


### PR DESCRIPTION
Updated raids recommendation items added the following are all in syntax some were already. [Muttadiles, zamorak godsword, ice barrage],[Vasa,zamorakian hasta, abyssal dagger, Blade of saeldor, ghrazi rapier, vengeance],[Guardians,Dragon pickaxe],[Mystics,Salve amulet(ei)],[Shamans,Sanfew serum(4), Antidote++(4)],[Vespula,Prayer potion(4), Super restore(4), Sanfew Serum(4)],[Tekton,Elder Maul, Abyssal Bludgeon, Vengeance],[Thieving,lockpick],[Ice Demon, fire surge]