### PR TITLE
raids: chronological ordering of items

### DIFF
--- a/raids/raids.gradle.kts
+++ b/raids/raids.gradle.kts
@@ -24,7 +24,7 @@ import ProjectVersions.rlVersion
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-version = "0.0.8"
+version = "0.0.9"
 
 project.extra["PluginName"] = "CoX Scouter"
 project.extra["PluginDescription"] = "Show helpful information for the Chambers of Xeric raid"

--- a/raids/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
+++ b/raids/src/main/java/net/runelite/client/plugins/raids/RaidsConfig.java
@@ -465,6 +465,30 @@ public interface RaidsConfig extends Config
 
 	@ConfigItem(
 		position = 32,
+		titleSection = "hideRooms",
+		keyName = "hideIceDemon",
+		name = "Hide Ice Demon raids",
+		description = "Display an overlay that shows information about the current party"
+	)
+	default boolean hideIceDemon()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 33,
+		titleSection = "hideRooms",
+		keyName = "hideThieving",
+		name = "Hide Thieving raids",
+		description = "Display an overlay that shows information about the current party"
+	)
+	default boolean hideThieving()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 34,
 		keyName = "partyDisplay",
 		name = "Party Info Display",
 		description = "Display an overlay that shows information about the current party"

--- a/raids/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
+++ b/raids/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
@@ -33,6 +33,7 @@ import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import javax.inject.Inject;
@@ -324,7 +325,7 @@ public class RaidsOverlay extends Overlay
 			bossMatches = plugin.getRotationMatches();
 		}
 
-		Set<Integer> imageIds = new HashSet<>();
+
 		for (Room layoutRoom : plugin.getRaid().getLayout().getRooms())
 		{
 			int position = layoutRoom.getPosition();

--- a/raids/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
+++ b/raids/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
@@ -323,8 +323,6 @@ public class RaidsOverlay extends Overlay
 		{
 			bossMatches = plugin.getRotationMatches();
 		}
-
-
 		for (Room layoutRoom : plugin.getRaid().getLayout().getRooms())
 		{
 			int position = layoutRoom.getPosition();

--- a/raids/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
+++ b/raids/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
@@ -322,8 +322,6 @@ public class RaidsOverlay extends Overlay
 		{
 			bossMatches = plugin.getRotationMatches();
 		}
-
-
 		for (Room layoutRoom : plugin.getRaid().getLayout().getRooms())
 		{
 			int position = layoutRoom.getPosition();

--- a/raids/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
+++ b/raids/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
@@ -24,6 +24,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 package net.runelite.client.plugins.raids;
 
 import java.awt.Color;
@@ -232,7 +233,7 @@ public class RaidsOverlay extends Overlay
 			puzzles = crabs ? "cr" : iceDemon ? "ri" : thieving ? "tr" : "?r";
 		}
 
-		if ((config.hideVanguards() && vanguards) || (config.hideRopeless() && !tightrope) || (config.hideUnknownCombat() && unknownCombat))
+		if ((config.hideVanguards() && vanguards) || (config.hideRopeless() && !tightrope) || (config.hideUnknownCombat() && unknownCombat || (config.hideIceDemon() && iceDemon || config.hideThieving() && thieving)))
 		{
 			panelComponent.getChildren().add(TitleComponent.builder()
 				.text("Bad Raid!")
@@ -322,6 +323,8 @@ public class RaidsOverlay extends Overlay
 		{
 			bossMatches = plugin.getRotationMatches();
 		}
+
+
 		for (Room layoutRoom : plugin.getRaid().getLayout().getRooms())
 		{
 			int position = layoutRoom.getPosition();

--- a/raids/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
+++ b/raids/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
@@ -24,7 +24,6 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 package net.runelite.client.plugins.raids;
 
 import java.awt.Color;

--- a/raids/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
+++ b/raids/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
@@ -318,6 +318,7 @@ public class RaidsOverlay extends Overlay
 		int bossCount = 0;
 		roomCount = 0;
 
+		Set<Integer> imageIds = new LinkedHashSet<>();
 		if (config.enableRotationWhitelist())
 		{
 			bossMatches = plugin.getRotationMatches();

--- a/raids/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
+++ b/raids/src/main/java/net/runelite/client/plugins/raids/RaidsOverlay.java
@@ -32,7 +32,6 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;


### PR DESCRIPTION
Add the item recommendation function to be in chronological order also removes unused import.