### PR TITLE
mirror: bring gpu support to a reasonable state

### DIFF
--- a/gpu/gpu.gradle.kts
+++ b/gpu/gpu.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.19"
+version = "0.0.20"
 
 project.extra["PluginName"] = "GPU"
 project.extra["PluginDescription"] = "Utilizes the GPU"
@@ -31,6 +31,7 @@ project.extra["PluginDescription"] = "Utilizes the GPU"
 dependencies {
     implementation(group = "net.runelite.gluegen", name = "gluegen-rt", version = "2.4.0-rc-20200429")
     implementation(group = "net.runelite.jogl", name = "jogl-all", version = "2.4.0-rc-20200429")
+    compileOnly(project(":mirror"))
 
     runtimeOnly(group = "net.runelite.gluegen", name = "gluegen-rt", version = "2.4.0-rc-20200429", classifier = "natives-linux-amd64")
     runtimeOnly(group = "net.runelite.gluegen", name = "gluegen-rt", version = "2.4.0-rc-20200429", classifier = "natives-windows-amd64")
@@ -58,6 +59,7 @@ tasks {
                     "Plugin-Version" to project.version,
                     "Plugin-Id" to nameToId(project.extra["PluginName"] as String),
                     "Plugin-Provider" to project.extra["PluginProvider"],
+                    "Plugin-Dependencies" to nameToId("mirror"),
                     "Plugin-Description" to project.extra["PluginDescription"],
                     "Plugin-License" to project.extra["PluginLicense"]
             ))

--- a/mirror/mirror.gradle.kts
+++ b/mirror/mirror.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.3"
+version = "0.0.4"
 
 project.extra["PluginName"] = "Mirror"
 project.extra["PluginDescription"] = "Creates a second window that contains the game screen minus the AFTER_MIRROR overlay"

--- a/mirror/src/main/java/net/runelite/client/plugins/mirror/MirrorPlugin.java
+++ b/mirror/src/main/java/net/runelite/client/plugins/mirror/MirrorPlugin.java
@@ -33,6 +33,9 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.PluginType;
 import org.pf4j.Extension;
 import java.awt.Canvas;
+import java.awt.Image;
+import java.awt.image.BufferedImage;
+import java.nio.Buffer;
 import javax.swing.JFrame;
 
 /**
@@ -52,7 +55,8 @@ public class MirrorPlugin extends Plugin
 	private Client client;
 
 	public static JFrame jframe;
-	public final Canvas canvas = new Canvas();
+	public static final Canvas canvas = new Canvas();
+	public static BufferedImage bufferedImage;
 
 	@Override
 	public void startUp()
@@ -65,6 +69,9 @@ public class MirrorPlugin extends Plugin
 			jframe.add(canvas);
 		}
 		client.setMirrored(true);
+
+		if (!jframe.isVisible())
+			jframe.setVisible(true);
 	}
 
 	@Override
@@ -84,9 +91,9 @@ public class MirrorPlugin extends Plugin
 		if (!jframe.isVisible())
 			jframe.setVisible(true);
 
-		if (canvas.getWidth() != event.image.getWidth(canvas) + 14 || (canvas.getHeight() != event.image.getHeight(canvas) + 40))
+		if (canvas.getWidth() != event.image.getWidth(canvas) + 15 || (canvas.getHeight() != event.image.getHeight(canvas) + 40))
 			{
-				canvas.setSize(event.image.getWidth(canvas) + 14, event.image.getHeight(canvas) + 40);
+				canvas.setSize(event.image.getWidth(canvas) + 15, event.image.getHeight(canvas) + 40);
 				jframe.setSize(canvas.getSize());
 			}
 		canvas.getGraphics().drawImage(event.image, 0, 0, jframe);


### PR DESCRIPTION
There is now no overhead while mirror is disabled.  
  
The actual drawing (pretty much all of the cpu time needed) is now done on a separate thread. (before it was all being done on client thread).
It will only draw a frame when the last one is complete. This allows the Mirror to fall behind the main client and makes higher resolution mirrors much more feasible. With a decent cpu you can do 1080p gpu mirroring now no problem, maybe even 1440p. The Higher the resolution and the weaker your cpu, the further mirror will fall behind. I advise users judge what resolution works best for them.

Stretched mode works, unless you are using a very small window (in which point, why the hell are you using stretched mode?)

Still not perfect but this is much closer to the goal.

