### PR TITLE
project: Add copyDeps task to copy runtime dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -181,6 +181,11 @@ subprojects {
             }
         }
     }
+    
+    tasks.register<Copy>("copyDeps") {
+        into("./build/deps/")
+        from(configurations["runtimeClasspath"])
+    }
 }
 
 tasks {


### PR DESCRIPTION
The `copyDeps` task will copy the runtime dependencies to the build/deps folder,
where they may be loaded by the `ExternalPluginManager` running in development
mode.

See https://github.com/open-osrs/runelite/pull/2611 for more info