### PR TITLE
Mes: multiple fixes

### DIFF
--- a/menuentryswapper/menuentryswapper.gradle.kts
+++ b/menuentryswapper/menuentryswapper.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.22"
+version = "0.0.23"
 
 project.extra["PluginName"] = "Menu Entry Swapper"
 project.extra["PluginDescription"] = "Change the default option that is displayed when hovering over objects"

--- a/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -307,18 +307,6 @@ public interface MenuEntrySwapperConfig extends Config
 		return GEItemCollectMode.DEFAULT;
 	}
 
-	@ConfigItem(
-		keyName = "swapGEAbort",
-		name = "GE Abort",
-		description = "Swap abort offer on Grand Exchange offers when shift-clicking",
-		position = 12,
-		section = "bankingSection",
-	)
-	default boolean swapGEAbort()
-	{
-		return false;
-	}
-
 	//------------------------------------------------------------//
 	// Equipment Swapper
 	//------------------------------------------------------------//
@@ -1684,10 +1672,22 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapClimbUpDown",
 		name = "Climb",
 		description = "Swap 'Climb-Up'/'Climb-Down' depending on Shift or Control key.",
-		position = 9,
+		position = 5,
 		section = "hotkeySwapping"
 	)
 	default boolean swapClimbUpDown()
+	{
+		return false;
+	}
+	
+	@ConfigItem(
+		keyName = "swapGEAbort",
+		name = "GE Abort",
+		description = "Swap abort offer on Grand Exchange offers when shift-clicking",
+		position = 6,
+		section = "hotkeySwapping",
+	)
+	default boolean swapGEAbort()
 	{
 		return false;
 	}

--- a/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -38,6 +38,7 @@ import net.runelite.client.plugins.menuentryswapper.util.CustomSwapParse;
 import net.runelite.client.plugins.menuentryswapper.util.DepositMode;
 import net.runelite.client.plugins.menuentryswapper.util.FairyRingMode;
 import net.runelite.client.plugins.menuentryswapper.util.FairyTreeMode;
+import net.runelite.client.plugins.menuentryswapper.util.GEItemCollectMode;
 import net.runelite.client.plugins.menuentryswapper.util.HouseAdvertisementMode;
 import net.runelite.client.plugins.menuentryswapper.util.HouseMode;
 import net.runelite.client.plugins.menuentryswapper.util.MaxCapeMode;
@@ -293,39 +294,27 @@ public interface MenuEntrySwapperConfig extends Config
 	{
 		return "";
 	}
-
+	
 	@ConfigItem(
-		keyName = "getSwapOffer",
-		name = "Offer-All",
-		description = "Swap 'Offer', on trades with 'Offer-All'",
+		keyName = "swapGEItemCollect",
+		name = "GE Item Collect",
+		description = "Swap Collect-notes, Collect-items, or Bank options from GE offer",
 		position = 11,
-		section = "miscellaneousSection"
+		section = "bankingSection",
 	)
-	default boolean getSwapOffer()
+	default GEItemCollectMode swapGEItemCollect()
 	{
-		return false;
+		return GEItemCollectMode.DEFAULT;
 	}
 
 	@ConfigItem(
-		keyName = "swapCoalBag",
-		name = "Coal Bag",
-		description = "Makes Empty the left click option when in a bank",
+		keyName = "swapGEAbort",
+		name = "GE Abort",
+		description = "Swap abort offer on Grand Exchange offers when shift-clicking",
 		position = 12,
-		section = "miscellaneousSection"
+		section = "bankingSection",
 	)
-	default boolean swapCoalBag()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "deprioritizeChopDown",
-		name = "Deprioritize Chop Down",
-		description = "Makes chop down appear below walk here on trees",
-		position = 13,
-		section = "miscellaneousSection"
-	)
-	default boolean deprioritizeChopDown()
+	default boolean swapGEAbort()
 	{
 		return false;
 	}
@@ -727,6 +716,42 @@ public interface MenuEntrySwapperConfig extends Config
 		section = "miscellaneousSection"
 	)
 	default boolean swapTeleportNames()
+	{
+		return false;
+	}
+	
+	@ConfigItem(
+		keyName = "getSwapOffer",
+		name = "Offer-All",
+		description = "Swap 'Offer', on trades with 'Offer-All'",
+		position = 20,
+		section = "miscellaneousSection"
+	)
+	default boolean getSwapOffer()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "swapCoalBag",
+		name = "Coal Bag",
+		description = "Makes Empty the left click option when in a bank",
+		position = 21,
+		section = "miscellaneousSection"
+	)
+	default boolean swapCoalBag()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "deprioritizeChopDown",
+		name = "Deprioritize Chop Down",
+		description = "Makes chop down appear below walk here on trees",
+		position = 22,
+		section = "miscellaneousSection"
+	)
+	default boolean deprioritizeChopDown()
 	{
 		return false;
 	}

--- a/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -300,7 +300,7 @@ public interface MenuEntrySwapperConfig extends Config
 		name = "GE Item Collect",
 		description = "Swap Collect-notes, Collect-items, or Bank options from GE offer",
 		position = 11,
-		section = "bankingSection",
+		section = "bankingSection"
 	)
 	default GEItemCollectMode swapGEItemCollect()
 	{
@@ -1685,7 +1685,7 @@ public interface MenuEntrySwapperConfig extends Config
 		name = "GE Abort",
 		description = "Swap abort offer on Grand Exchange offers when Hotkey active.",
 		position = 6,
-		section = "hotkeySwapping",
+		section = "hotkeySwapping"
 	)
 	default boolean swapGEAbort()
 	{

--- a/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -558,7 +558,7 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "home",
+		keyName = "swapHomePortalMode",
 		name = "Mode",
 		description = "",
 		position = 6,

--- a/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -1671,7 +1671,7 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapClimbUpDown",
 		name = "Climb",
-		description = "Swap 'Climb-Up'/'Climb-Down' depending on Shift or Control key.",
+		description = "Swap 'Climb-Up'/'Climb-Down' depending on Hotkey or Control key.",
 		position = 5,
 		section = "hotkeySwapping"
 	)
@@ -1683,7 +1683,7 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "swapGEAbort",
 		name = "GE Abort",
-		description = "Swap abort offer on Grand Exchange offers when shift-clicking",
+		description = "Swap abort offer on Grand Exchange offers when Hotkey active.",
 		position = 6,
 		section = "hotkeySwapping",
 	)

--- a/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -138,8 +138,8 @@ public class MenuEntrySwapperPlugin extends Plugin
 	);
 	private static final List<String> dropOre = Arrays.asList(
 		"Copper ore", "Tin ore", "Limestone", "Blurite ore", "Iron ore", "Elemental ore", "Daeyalt ore",
-		"Silver ore", "Coal", "Sandstone", "Gold ore", "Granite", "Mithril ore", "Lovakite ore",
-		"Adamantite ore", "Runite ore", "Amethyst ore"
+		"Silver ore", "Coal", "Sandstone", "Gold ore", "Granite (500g)", "Granite (2kg)", "Granite (5kg)", 
+		"Mithril ore", "Lovakite ore", "Adamantite ore", "Runite ore", "Amethyst ore"
 	);
 	private static final List<String> dropLogs = Arrays.asList(
 		"Logs", "Achey tree logs", "Oak logs", "Willow logs", "Teak logs", "Juniper logs", "Maple logs",

--- a/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -82,8 +82,6 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.plugins.PluginType;
 import net.runelite.client.plugins.menuentryswapper.comparables.GrimyHerbComparableEntry;
-import net.runelite.client.plugins.menuentryswapper.util.DepositMode;
-import net.runelite.client.plugins.menuentryswapper.util.WithdrawMode;
 import net.runelite.client.util.HotkeyListener;
 import static net.runelite.client.util.MenuUtil.swap;
 import org.pf4j.Extension;
@@ -138,7 +136,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 	);
 	private static final List<String> dropOre = Arrays.asList(
 		"Copper ore", "Tin ore", "Limestone", "Blurite ore", "Iron ore", "Elemental ore", "Daeyalt ore",
-		"Silver ore", "Coal", "Sandstone", "Gold ore", "Granite (500g)", "Granite (2kg)", "Granite (5kg)", 
+		"Silver ore", "Coal", "Sandstone", "Gold ore", "Granite (500g)", "Granite (2kg)", "Granite (5kg)",
 		"Mithril ore", "Lovakite ore", "Adamantite ore", "Runite ore", "Amethyst ore"
 	);
 	private static final List<String> dropLogs = Arrays.asList(
@@ -1431,13 +1429,13 @@ public class MenuEntrySwapperPlugin extends Plugin
 				break;
 			case DEPOSIT_10:
 				menuManager.addPriorityEntry(new BankComparableEntry("Deposit-10", "", false));
-				break;	
+				break;
 			case DEPOSIT_X:
-				menuManager.addPriorityEntry(new BankComparableEntry("Deposit-X", "", false));	
-				break;		
+				menuManager.addPriorityEntry(new BankComparableEntry("Deposit-X", "", false));
+				break;
 			case DEPOSIT_ALL:
 				menuManager.addPriorityEntry(new BankComparableEntry("Deposit-All", "", false));
-				break;	
+				break;
 			case EXTRA_OP:
 				menuManager.addPriorityEntry(new BankComparableEntry("wield", "", false));
 				menuManager.addPriorityEntry(new BankComparableEntry("wear", "", false));
@@ -1457,7 +1455,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 				menuManager.removePriorityEntry(new BankComparableEntry("Deposit-1", "", false));
 				menuManager.removePriorityEntry(new BankComparableEntry("Deposit-5", "", false));
 				menuManager.removePriorityEntry(new BankComparableEntry("Deposit-10", "", false));
-				menuManager.removePriorityEntry(new BankComparableEntry("Deposit-X", "", false));	
+				menuManager.removePriorityEntry(new BankComparableEntry("Deposit-X", "", false));
 				break;
 		}
 		switch (config.bankWithdrawShiftClick())
@@ -1470,13 +1468,13 @@ public class MenuEntrySwapperPlugin extends Plugin
 				break;
 			case WITHDRAW_10:
 				menuManager.addPriorityEntry(new BankComparableEntry("Withdraw-10", "", false));
-				break;	
+				break;
 			case WITHDRAW_X:
-				menuManager.addPriorityEntry(new BankComparableEntry("Withdraw-X", "", false));	
-				break;		
+				menuManager.addPriorityEntry(new BankComparableEntry("Withdraw-X", "", false));
+				break;
 			case WITHDRAW_ALL:
 				menuManager.addPriorityEntry(new BankComparableEntry("Withdraw-All", "", false));
-				break;	
+				break;
 			case WITHDRAW_ALL_BUT_1:
 				menuManager.addPriorityEntry(new BankComparableEntry("Withdraw-All-But-1", "", false));
 				break;
@@ -1484,7 +1482,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 				menuManager.removePriorityEntry(new BankComparableEntry("Withdraw-1", "", false));
 				menuManager.removePriorityEntry(new BankComparableEntry("Withdraw-5", "", false));
 				menuManager.removePriorityEntry(new BankComparableEntry("Withdraw-10", "", false));
-				menuManager.removePriorityEntry(new BankComparableEntry("Withdraw-X", "", false));	
+				menuManager.removePriorityEntry(new BankComparableEntry("Withdraw-X", "", false));
 				menuManager.removePriorityEntry(new BankComparableEntry("Withdraw-All", "", false));
 				menuManager.removePriorityEntry(new BankComparableEntry("Withdraw-All-But-1", "", false));
 				break;
@@ -1528,13 +1526,13 @@ public class MenuEntrySwapperPlugin extends Plugin
 				break;
 			case DEPOSIT_10:
 				menuManager.removePriorityEntry(new BankComparableEntry("Deposit-10", "", false));
-				break;	
+				break;
 			case DEPOSIT_X:
-				menuManager.removePriorityEntry(new BankComparableEntry("Deposit-X", "", false));	
-				break;		
+				menuManager.removePriorityEntry(new BankComparableEntry("Deposit-X", "", false));
+				break;
 			case DEPOSIT_ALL:
 				menuManager.removePriorityEntry(new BankComparableEntry("Deposit-All", "", false));
-				break;	
+				break;
 			case EXTRA_OP:
 				menuManager.removePriorityEntry(new BankComparableEntry("wield", "", false));
 				menuManager.removePriorityEntry(new BankComparableEntry("wear", "", false));
@@ -1554,7 +1552,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 				menuManager.removePriorityEntry(new BankComparableEntry("Deposit-1", "", false));
 				menuManager.removePriorityEntry(new BankComparableEntry("Deposit-5", "", false));
 				menuManager.removePriorityEntry(new BankComparableEntry("Deposit-10", "", false));
-				menuManager.removePriorityEntry(new BankComparableEntry("Deposit-X", "", false));	
+				menuManager.removePriorityEntry(new BankComparableEntry("Deposit-X", "", false));
 				break;
 		}
 		switch (config.bankWithdrawShiftClick())
@@ -1567,13 +1565,13 @@ public class MenuEntrySwapperPlugin extends Plugin
 				break;
 			case WITHDRAW_10:
 				menuManager.removePriorityEntry(new BankComparableEntry("Withdraw-10", "", false));
-				break;	
+				break;
 			case WITHDRAW_X:
-				menuManager.removePriorityEntry(new BankComparableEntry("Withdraw-X", "", false));	
-				break;		
+				menuManager.removePriorityEntry(new BankComparableEntry("Withdraw-X", "", false));
+				break;
 			case WITHDRAW_ALL:
 				menuManager.removePriorityEntry(new BankComparableEntry("Withdraw-All", "", false));
-				break;	
+				break;
 			case WITHDRAW_ALL_BUT_1:
 				menuManager.removePriorityEntry(new BankComparableEntry("Withdraw-All-But-1", "", false));
 				break;
@@ -1581,7 +1579,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 				menuManager.removePriorityEntry(new BankComparableEntry("Withdraw-1", "", false));
 				menuManager.removePriorityEntry(new BankComparableEntry("Withdraw-5", "", false));
 				menuManager.removePriorityEntry(new BankComparableEntry("Withdraw-10", "", false));
-				menuManager.removePriorityEntry(new BankComparableEntry("Withdraw-X", "", false));	
+				menuManager.removePriorityEntry(new BankComparableEntry("Withdraw-X", "", false));
 				menuManager.removePriorityEntry(new BankComparableEntry("Withdraw-All", "", false));
 				menuManager.removePriorityEntry(new BankComparableEntry("Withdraw-All-But-1", "", false));
 				break;

--- a/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -820,16 +820,16 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 		if (config.swapTravel())
 		{
-			menuManager.addPriorityEntry("Travel");
-			menuManager.addPriorityEntry("Pay-fare");
-			menuManager.addPriorityEntry("Charter");
-			menuManager.addPriorityEntry("Take-boat");
-			menuManager.addPriorityEntry("Fly");
-			menuManager.addPriorityEntry("Jatizso");
-			menuManager.addPriorityEntry("Neitiznot");
-			menuManager.addPriorityEntry("Rellekka");
+			menuManager.addPriorityEntry("Travel").setPriority(10);
+			menuManager.addPriorityEntry("Pay-fare").setPriority(10);
+			menuManager.addPriorityEntry("Charter").setPriority(10);
+			menuManager.addPriorityEntry("Take-boat").setPriority(10);
+			menuManager.addPriorityEntry("Fly").setPriority(10);
+			menuManager.addPriorityEntry("Jatizso").setPriority(10);
+			menuManager.addPriorityEntry("Neitiznot").setPriority(10);
+			menuManager.addPriorityEntry("Rellekka").setPriority(10);
 			menuManager.addPriorityEntry("Follow", "Elkoy").setPriority(10);
-			menuManager.addPriorityEntry("Transport");
+			menuManager.addPriorityEntry("Transport").setPriority(10);
 		}
 
 		if (config.swapAbyssTeleport())

--- a/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -1096,17 +1096,9 @@ public class MenuEntrySwapperPlugin extends Plugin
 				break;
 		}
 
-		switch (config.swapHomePortalMode())
+		if (config.swapHomePortal())
 		{
-			case HOME:
-				menuManager.addPriorityEntry("Home");
-				break;
-			case BUILD_MODE:
-				menuManager.addPriorityEntry("Build mode");
-				break;
-			case FRIENDS_HOUSE:
-				menuManager.addPriorityEntry("Friend's house");
-				break;
+			menuManager.addPriorityEntry(config.swapHomePortalMode().toString(), "Portal").setPriority(100);
 		}
 
 		if (config.swapHardWoodGrove())
@@ -1126,7 +1118,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 		if (config.swapHouseAd())
 		{
-			menuManager.addPriorityEntry(config.swapHouseAdMode().getEntry());
+			menuManager.addPriorityEntry(config.swapHouseAdMode().toString(), "House Advertisement");
 		}
 
 		if (config.getSwapGrimyHerb())
@@ -1300,7 +1292,6 @@ public class MenuEntrySwapperPlugin extends Plugin
 		menuManager.removePriorityEntry(config.constructionCapeMode().toString(), "Construct. cape(t)");
 		menuManager.removePriorityEntry(config.maxMode().toString(), "max cape");
 		menuManager.removePriorityEntry(config.questCapeMode().toString(), "quest point cape");
-		menuManager.removePriorityEntry(config.swapHouseAdMode().getEntry());
 		menuManager.removeSwap("Bury", "bone", "Use");
 		menuManager.removeSwap("Wield", "salamander", "Release");
 		menuManager.removeSwap("Wield", "Swamp lizard", "Release");
@@ -1309,6 +1300,8 @@ public class MenuEntrySwapperPlugin extends Plugin
 		menuManager.removePriorityEntry(EMPTY_MEDIUM);
 		menuManager.removePriorityEntry(EMPTY_LARGE);
 		menuManager.removePriorityEntry(EMPTY_GIANT);
+		menuManager.removePriorityEntry(config.swapHomePortalMode().toString(), "Portal");
+		menuManager.removePriorityEntry(config.swapHouseAdMode().toString(), "House Advertisement");
 		for (String jewellerybox : jewelleryBox)
 		{
 			menuManager.removePriorityEntry(jewellerybox, "basic jewellery box");
@@ -1387,19 +1380,6 @@ public class MenuEntrySwapperPlugin extends Plugin
 				break;
 			case TELEPORT_TO_DESTINATION:
 				menuManager.removePriorityEntry("Teleport to destination", "Obelisk");
-				break;
-		}
-
-		switch (config.swapHomePortalMode())
-		{
-			case HOME:
-				menuManager.removePriorityEntry("Home");
-				break;
-			case BUILD_MODE:
-				menuManager.removePriorityEntry("Build mode");
-				break;
-			case FRIENDS_HOUSE:
-				menuManager.removePriorityEntry("Friend's house");
 				break;
 		}
 
@@ -1588,7 +1568,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 	private void updateBuySellEntries()
 	{
 		List<String> tmp;
-
+	
 		if (config.getSwapBuyOne())
 		{
 			tmp = Text.fromCSV(config.getBuyOneItems());
@@ -1718,7 +1698,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 	{
 		List<String> tmp;
 
-		if (config.getWithdrawOne())
+		if (config.getWithdrawOne() && !hotkeyActive)
 		{
 			tmp = Text.fromCSV(config.getWithdrawOneItems());
 			withdrawEntries[0] = new AbstractComparableEntry[tmp.size()];
@@ -1730,7 +1710,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 			withdrawEntries[0] = null;
 		}
 
-		if (config.getWithdrawFive())
+		if (config.getWithdrawFive() && !hotkeyActive)
 		{
 			tmp = Text.fromCSV(config.getWithdrawFiveItems());
 			withdrawEntries[1] = new AbstractComparableEntry[tmp.size()];
@@ -1742,7 +1722,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 			withdrawEntries[1] = null;
 		}
 
-		if (config.getWithdrawTen())
+		if (config.getWithdrawTen() && !hotkeyActive)
 		{
 			tmp = Text.fromCSV(config.getWithdrawTenItems());
 			withdrawEntries[2] = new AbstractComparableEntry[tmp.size()];
@@ -1754,7 +1734,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 			withdrawEntries[2] = null;
 		}
 
-		if (config.getWithdrawX())
+		if (config.getWithdrawX() && !hotkeyActive)
 		{
 			tmp = Text.fromCSV(config.getWithdrawXItems());
 			withdrawEntries[3] = new AbstractComparableEntry[tmp.size()];
@@ -1766,7 +1746,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 			withdrawEntries[3] = null;
 		}
 
-		if (config.getWithdrawAll())
+		if (config.getWithdrawAll() && !hotkeyActive)
 		{
 			tmp = Text.fromCSV(config.getWithdrawAllItems());
 			withdrawEntries[4] = new AbstractComparableEntry[tmp.size()];

--- a/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -1124,11 +1124,6 @@ public class MenuEntrySwapperPlugin extends Plugin
 			}
 		}
 		
-		if (config.swapGEAbort())
-		{
-			menuManager.addPriorityEntry("Abort offer");
-		}
-		
 		switch (config.swapGEItemCollect())
 		{
 			case ITEMS:
@@ -1277,7 +1272,6 @@ public class MenuEntrySwapperPlugin extends Plugin
 		menuManager.removePriorityEntry(EMPTY_GIANT);
 		menuManager.removePriorityEntry(config.swapHomePortalMode().toString(), "Portal");
 		menuManager.removePriorityEntry(config.swapHouseAdMode().toString(), "House Advertisement");
-		menuManager.removePriorityEntry("Abort offer");
 		for (String jewellerybox : jewelleryBox)
 		{
 			menuManager.removePriorityEntry(jewellerybox, "basic jewellery box");
@@ -1422,6 +1416,11 @@ public class MenuEntrySwapperPlugin extends Plugin
 			}
 		}
 		
+		if (config.swapGEAbort())
+		{
+			menuManager.addPriorityEntry("Abort offer");
+		}
+		
 		switch (config.bankDepositShiftClick())
 		{
 			case DEPOSIT_1:
@@ -1512,6 +1511,11 @@ public class MenuEntrySwapperPlugin extends Plugin
 			{
 				menuManager.removePriorityEntry(npccontact, "npc contact");
 			}
+		}
+		
+				if (config.swapGEAbort())
+		{
+			menuManager.removePriorityEntry("Abort offer");
 		}
 		
 		switch (config.bankDepositShiftClick())

--- a/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -1043,7 +1043,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 		if (config.swapHomePortal())
 		{
-			menuManager.addPriorityEntry(config.swapHomePortalMode().toString(), "Portal").setPriority(100);
+			menuManager.addPriorityEntry(config.swapHomePortalMode().toString(), "Portal").setPriority(10);
 		}
 
 		if (config.swapHardWoodGrove())

--- a/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -1123,6 +1123,34 @@ public class MenuEntrySwapperPlugin extends Plugin
 				menuManager.addSwap("Use", dropLogs, "Drop");
 			}
 		}
+		
+		if (config.swapGEAbort())
+		{
+			menuManager.addPriorityEntry("Abort offer");
+		}
+		
+		switch (config.swapGEItemCollect())
+		{
+			case ITEMS:
+				menuManager.addPriorityEntry(new BankComparableEntry("collect-items", "", false));
+				menuManager.addPriorityEntry(new BankComparableEntry("collect-item", "", false));
+				break;
+			case NOTES:
+				menuManager.addPriorityEntry(new BankComparableEntry("collect-notes", "", false));
+				menuManager.addPriorityEntry(new BankComparableEntry("collect-note", "", false));
+				break;
+			case BANK:
+				menuManager.addPriorityEntry(new BankComparableEntry("collect to bank", "", false));
+				menuManager.addPriorityEntry(new BankComparableEntry("bank", "", false));
+				break;
+			case DEFAULT:
+				menuManager.removePriorityEntry(new BankComparableEntry("collect to bank", "", false));
+				menuManager.removePriorityEntry(new BankComparableEntry("bank", "", false));
+				menuManager.removePriorityEntry(new BankComparableEntry("collect-notes", "", false));
+				menuManager.removePriorityEntry(new BankComparableEntry("collect-note", "", false));
+				menuManager.removePriorityEntry(new BankComparableEntry("collect-items", "", false));
+				menuManager.removePriorityEntry(new BankComparableEntry("collect-item", "", false));
+		}
 	}
 
 	private void removeSwaps()
@@ -1249,6 +1277,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		menuManager.removePriorityEntry(EMPTY_GIANT);
 		menuManager.removePriorityEntry(config.swapHomePortalMode().toString(), "Portal");
 		menuManager.removePriorityEntry(config.swapHouseAdMode().toString(), "House Advertisement");
+		menuManager.removePriorityEntry("Abort offer");
 		for (String jewellerybox : jewelleryBox)
 		{
 			menuManager.removePriorityEntry(jewellerybox, "basic jewellery box");
@@ -1328,6 +1357,29 @@ public class MenuEntrySwapperPlugin extends Plugin
 			case TELEPORT_TO_DESTINATION:
 				menuManager.removePriorityEntry("Teleport to destination", "Obelisk");
 				break;
+		}
+		
+		switch (config.swapGEItemCollect())
+		{
+			case ITEMS:
+				menuManager.removePriorityEntry(new BankComparableEntry("collect-items", "", false));
+				menuManager.removePriorityEntry(new BankComparableEntry("collect-item", "", false));
+				break;
+			case NOTES:
+				menuManager.removePriorityEntry(new BankComparableEntry("collect-notes", "", false));
+				menuManager.removePriorityEntry(new BankComparableEntry("collect-note", "", false));
+				break;
+			case BANK:
+				menuManager.removePriorityEntry(new BankComparableEntry("collect to bank", "", false));
+				menuManager.removePriorityEntry(new BankComparableEntry("bank", "", false));
+				break;
+			case DEFAULT:
+				menuManager.removePriorityEntry(new BankComparableEntry("collect to bank", "", false));
+				menuManager.removePriorityEntry(new BankComparableEntry("bank", "", false));
+				menuManager.removePriorityEntry(new BankComparableEntry("collect-notes", "", false));
+				menuManager.removePriorityEntry(new BankComparableEntry("collect-note", "", false));
+				menuManager.removePriorityEntry(new BankComparableEntry("collect-items", "", false));
+				menuManager.removePriorityEntry(new BankComparableEntry("collect-item", "", false));
 		}
 
 	}

--- a/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/util/DepositMode.java
+++ b/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/util/DepositMode.java
@@ -31,17 +31,15 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum DepositMode
 {
-	DEPOSIT_1("Deposit-1", 3, 2),
-	DEPOSIT_5("Deposit-5", 4, 3),
-	DEPOSIT_10("Deposit-10", 5, 4),
-	DEPOSIT_X("Deposit-X", 6, 6),
-	DEPOSIT_ALL("Deposit-All", 8, 5),
-	EXTRA_OP("Eat/Wield/Etc.", 9, 0),
-	OFF("Off", 0, 0);
+	DEPOSIT_1("Deposit-1"),
+	DEPOSIT_5("Deposit-5"),
+	DEPOSIT_10("Deposit-10"),
+	DEPOSIT_X("Deposit-X"),
+	DEPOSIT_ALL("Deposit-All"),
+	EXTRA_OP("Eat/Wield/Etc."),
+	OFF("Off");
 
 	private final String name;
-	private final int identifier;
-	private final int identifierDepositBox;
 
 	@Override
 	public String toString()

--- a/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/util/GEItemCollectMode.Java
+++ b/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/util/GEItemCollectMode.Java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2019, Rami <https://github.com/Rami-J>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.menuentryswapper;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GEItemCollectMode
+{
+	DEFAULT("Default"),
+	ITEMS("Collect-items"),
+	NOTES("Collect-notes"),
+	BANK("Bank");
+
+	private final String name;
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}

--- a/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/util/GEItemCollectMode.java
+++ b/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/util/GEItemCollectMode.java
@@ -37,6 +37,11 @@ public enum GEItemCollectMode
 	BANK("Bank");
 
 	private final String name;
+	
+	GEItemCollectMode(String name)
+	{
+		this.name = name;
+	}
 
 	@Override
 	public String toString()

--- a/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/util/GEItemCollectMode.java
+++ b/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/util/GEItemCollectMode.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.menuentryswapper;
+package net.runelite.client.plugins.menuentryswapper.util;
 
 public enum GEItemCollectMode
 {

--- a/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/util/GEItemCollectMode.java
+++ b/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/util/GEItemCollectMode.java
@@ -24,11 +24,6 @@
  */
 package net.runelite.client.plugins.menuentryswapper;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
-@Getter
-@RequiredArgsConstructor
 public enum GEItemCollectMode
 {
 	DEFAULT("Default"),

--- a/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/util/HouseAdvertisementMode.java
+++ b/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/util/HouseAdvertisementMode.java
@@ -24,11 +24,6 @@
  */
 package net.runelite.client.plugins.menuentryswapper.util;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
-@Getter
-@RequiredArgsConstructor
 public enum HouseAdvertisementMode
 {
 	VIEW("View"),

--- a/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/util/HouseAdvertisementMode.java
+++ b/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/util/HouseAdvertisementMode.java
@@ -26,19 +26,21 @@ package net.runelite.client.plugins.menuentryswapper.util;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import net.runelite.client.menus.AbstractComparableEntry;
-import static net.runelite.client.menus.ComparableEntries.newBaseComparableEntry;
 
 @Getter
 @RequiredArgsConstructor
 public enum HouseAdvertisementMode
 {
-	VIEW("View", newBaseComparableEntry("View", "House Advertisement")),
-	ADD_HOUSE("Add-House", newBaseComparableEntry("Add-House", "House Advertisement")),
-	VISIT_LAST("Visit-Last", newBaseComparableEntry("Visit-Last", "House Advertisement"));
+	VIEW("View"),
+	ADD_HOUSE("Add-House"),
+	VISIT_LAST("Visit-Last");
 
 	private final String name;
-	private final AbstractComparableEntry entry;
+	
+	HouseAdvertisementMode(String name)
+	{
+		this.name = name;
+	}
 
 	@Override
 	public String toString()

--- a/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/util/HouseMode.java
+++ b/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/util/HouseMode.java
@@ -25,11 +25,6 @@
 
 package net.runelite.client.plugins.menuentryswapper.util;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
-@Getter
-@RequiredArgsConstructor
 public enum HouseMode
 {
 	ENTER("Enter"),

--- a/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/util/HouseMode.java
+++ b/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/util/HouseMode.java
@@ -38,6 +38,11 @@ public enum HouseMode
 	FRIENDS_HOUSE("Friend's House");
 
 	private final String name;
+	
+	HouseMode(String name)
+	{
+		this.name = name;
+	}
 
 	@Override
 	public String toString()

--- a/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/util/WithdrawMode.java
+++ b/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/util/WithdrawMode.java
@@ -26,23 +26,20 @@ package net.runelite.client.plugins.menuentryswapper.util;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import net.runelite.api.MenuOpcode;
 
 @Getter
 @RequiredArgsConstructor
 public enum WithdrawMode
 {
-	WITHDRAW_1("Withdraw-1", MenuOpcode.CC_OP, 2),
-	WITHDRAW_5("Withdraw-5", MenuOpcode.CC_OP, 3),
-	WITHDRAW_10("Withdraw-10", MenuOpcode.CC_OP, 4),
-	WITHDRAW_X("Withdraw-X", MenuOpcode.CC_OP, 5),
-	WITHDRAW_ALL("Withdraw-All", MenuOpcode.CC_OP_LOW_PRIORITY, 7),
-	WITHDRAW_ALL_BUT_1("Withdraw-All-But-1", MenuOpcode.CC_OP_LOW_PRIORITY, 8),
-	OFF("Off", MenuOpcode.UNKNOWN, 0);
+	WITHDRAW_1("Withdraw-1"),
+	WITHDRAW_5("Withdraw-5"),
+	WITHDRAW_10("Withdraw-10"),
+	WITHDRAW_X("Withdraw-X"),
+	WITHDRAW_ALL("Withdraw-All"),
+	WITHDRAW_ALL_BUT_1("Withdraw-All-But-1"),
+	OFF("Off");
 
 	private final String name;
-	private final MenuOpcode menuOpcode;
-	private final int identifier;
 
 	@Override
 	public String toString()


### PR DESCRIPTION
Fixes:
1) Withdraw/deposit under banking overwriting shift options.
2) House swaps.
3) House ad swaps.
4) Runelites awful way of doing shift options
5) Granite cannonballs being dropped when enabling drop ores.
6) Config issue with house swaps.
7) trade options taking priority over travel options

adds:

1) Swap Collect-notes, Collect-items, or Bank options from GE offer.
2) Swap abort offer on Grand Exchange offer on Hotkey