### PR TITLE
xptracker: fix overlaymenuclicked

### DIFF
--- a/xptracker/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/xptracker/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -26,7 +26,9 @@
 package net.runelite.client.plugins.xptracker;
 
 import com.google.common.annotations.VisibleForTesting;
+
 import static com.google.common.base.MoreObjects.firstNonNull;
+
 import com.google.inject.Binder;
 import com.google.inject.Provides;
 import java.awt.image.BufferedImage;
@@ -58,7 +60,9 @@ import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.events.StatChanged;
 import net.runelite.api.util.Text;
 import net.runelite.api.widgets.WidgetID;
+
 import static net.runelite.api.widgets.WidgetInfo.TO_GROUP;
+
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.OverlayMenuClicked;
@@ -67,7 +71,9 @@ import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.PluginType;
+
 import static net.runelite.client.plugins.xptracker.XpWorldType.NORMAL;
+
 import net.runelite.client.task.Schedule;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
@@ -746,11 +752,18 @@ public class XpTrackerPlugin extends Plugin
 	@Subscribe
 	public void onOverlayMenuClicked(OverlayMenuClicked event)
 	{
-		final Skill skill = Skill.valueOf(Text.removeTags(event.getEntry().getTarget()).toUpperCase());
-
 		if (event.getEntry().getMenuOpcode() == MenuOpcode.RUNELITE_OVERLAY &&
 			event.getEntry().getTarget() != null)
 		{
+			final Skill skill;
+			try
+			{
+				skill = Skill.valueOf(Text.removeTags(event.getEntry().getTarget()).toUpperCase());
+			}
+			catch (IllegalArgumentException e)
+			{
+				return;
+			}
 			String option = event.getEntry().getOption();
 			switch (option)
 			{

--- a/xptracker/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
+++ b/xptracker/src/main/java/net/runelite/client/plugins/xptracker/XpTrackerPlugin.java
@@ -26,9 +26,6 @@
 package net.runelite.client.plugins.xptracker;
 
 import com.google.common.annotations.VisibleForTesting;
-
-import static com.google.common.base.MoreObjects.firstNonNull;
-
 import com.google.inject.Binder;
 import com.google.inject.Provides;
 import java.awt.image.BufferedImage;
@@ -60,9 +57,6 @@ import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.events.StatChanged;
 import net.runelite.api.util.Text;
 import net.runelite.api.widgets.WidgetID;
-
-import static net.runelite.api.widgets.WidgetInfo.TO_GROUP;
-
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.OverlayMenuClicked;
@@ -71,9 +65,6 @@ import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.PluginType;
-
-import static net.runelite.client.plugins.xptracker.XpWorldType.NORMAL;
-
 import net.runelite.client.task.Schedule;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
@@ -81,6 +72,9 @@ import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.ImageUtil;
 import net.runelite.http.api.xp.XpClient;
 import org.pf4j.Extension;
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static net.runelite.api.widgets.WidgetInfo.TO_GROUP;
+import static net.runelite.client.plugins.xptracker.XpWorldType.NORMAL;
 
 @Extension
 @PluginDescriptor(

--- a/xptracker/xptracker.gradle.kts
+++ b/xptracker/xptracker.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.7"
+version = "0.0.8"
 
 project.extra["PluginName"] = "XP Tracker"
 project.extra["PluginDescription"] = "Enable the XP Tracker panel"


### PR DESCRIPTION
The plugin was trying to call Skill.valueOf() on something that might not be a valid argument if you're clicking other overlay menu entries than the ones from the xp tracker plugin. This catches the exception. 

The white spaces in the imports were added by IntelliJ when I told it to do the auto checkstyle thing so I'm just gonna leave them there. 