### PR TITLE
classic-377: disabled by default

### DIFF
--- a/classic-377/src/main/java/com/openosrs/classic377/RSClassic377Plugin.java
+++ b/classic-377/src/main/java/com/openosrs/classic377/RSClassic377Plugin.java
@@ -27,7 +27,8 @@ import org.pf4j.Extension;
 @PluginDescriptor(
 	name = "RS Classic 377",
 	description = "RS Classic Rev 377",
-	type = PluginType.MISCELLANEOUS
+	type = PluginType.MISCELLANEOUS,
+	enabledByDefault = false
 )
 @Slf4j
 public class RSClassic377Plugin extends Plugin


### PR DESCRIPTION
Such a significant plugin should not be enabled by default, which is especially annoying when all plugins get installed, which happens in development mode.