### PR TITLE
max-hit: slightly change how it's displayed

### DIFF
--- a/maxhit/maxhit.gradle.kts
+++ b/maxhit/maxhit.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.2"
+version = "0.0.3"
 
 project.extra["PluginName"] = "Max Hit"
 project.extra["PluginDescription"] = "Adds the max hit of the equipped weapon to the equipment and stats widget"

--- a/maxhit/src/main/java/net/runelite/client/plugins/maxhit/MaxHitPlugin.java
+++ b/maxhit/src/main/java/net/runelite/client/plugins/maxhit/MaxHitPlugin.java
@@ -94,13 +94,17 @@ public class MaxHitPlugin extends Plugin
 
 	private void setWidgetMaxHit(MaxHit maxhit)
 	{
-		Widget equipYourCharacter = client.getWidget(WidgetInfo.EQUIP_YOUR_CHARACTER);
-		String maxHitText = "Melee Max Hit: " + maxhit.getMaxMeleeHit();
-		maxHitText += "<br>Range Max Hit: " + maxhit.getMaxRangeHit();
-		maxHitText += "<br>Magic Max Hit: " + maxhit.getMaxMagicHit();
+		Widget equipmentPanel = client.getWidget(WidgetInfo.EQUIP_YOUR_CHARACTER);
+		if (equipmentPanel != null)
+		{
+			Widget equipYourCharacter = equipmentPanel.getChildren()[1];
+			String maxHitText = "Max Hit:  Melee: " + maxhit.getMaxMeleeHit();
+			maxHitText += " - Ranged: " + maxhit.getMaxRangeHit();
+			maxHitText += " - Magic: " + maxhit.getMaxMagicHit();
 
 
-		equipYourCharacter.setText(maxHitText);
+			equipYourCharacter.setText(maxHitText);
+		}
 	}
 
 	private static class MaxHit


### PR DESCRIPTION
Looks a little bit cleaner, no redundant "Max Hit"

![image](https://user-images.githubusercontent.com/2943260/89110550-b1c57480-d419-11ea-8c17-07229cbf9504.png)
