### PR TITLE
menuentry-swapper: added Mythical Cape teleport swap

### DIFF
--- a/menuentryswapper/menuentryswapper.gradle.kts
+++ b/menuentryswapper/menuentryswapper.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.24"
+version = "0.0.25"
 
 project.extra["PluginName"] = "Menu Entry Swapper"
 project.extra["PluginDescription"] = "Change the default option that is displayed when hovering over objects"

--- a/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -463,6 +463,18 @@ public interface MenuEntrySwapperConfig extends Config
 		return QuestCapeMode.TELEPORT;
 	}
 
+	@ConfigItem(
+		keyName = "swapMythicalCape",
+		name = "Mythical Cape",
+		description = "Enables swapping of 'Teleport' and 'Wear'.",
+		position = 12,
+		section = "equipmentSwapperSection"
+	)
+	default boolean getSwapMythicalCape()
+	{
+		return true;
+	}
+
 	//------------------------------------------------------------//
 	// Miscellaneous
 	//------------------------------------------------------------//

--- a/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -766,6 +766,11 @@ public class MenuEntrySwapperPlugin extends Plugin
 			menuManager.addPriorityEntry("Teleport", "Explorer's ring 4");
 		}
 
+		if (config.getSwapMythicalCape())
+		{
+			menuManager.addPriorityEntry("Teleport", "Mythical Cape");
+		}
+
 		if (config.swapHardWoodGrove())
 		{
 			menuManager.addPriorityEntry("Send-parcel", "Rionasta");
@@ -1231,6 +1236,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		menuManager.removePriorityEntry("Teleport", "Explorer's ring 2");
 		menuManager.removePriorityEntry("Teleport", "Explorer's ring 3");
 		menuManager.removePriorityEntry("Teleport", "Explorer's ring 4");
+		menuManager.removePriorityEntry("Teleport", "Mythical Cape");
 		menuManager.removePriorityEntry("Teleport", "Mage of zamorak");
 		menuManager.removePriorityEntry("Teleport", "Mounted Strength Cape");
 		menuManager.removePriorityEntry("Teleport", "Mounted Strength Cape (t)");


### PR DESCRIPTION
Added support to swap "teleport" above "wear" for the
Mythical cape.
The config item was added at the bottom of the "Equipment"
section. The logic is handled below Explorer's ring (as
that use case is a close match).