### PR TITLE
gradle: Support build argument to automatically copy to externalmanager

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ allprojects {
 }
 
 subprojects {
+    var subprojectName = name
     group = "com.openosrs.externals"
 
     project.extra["PluginProvider"] = "OpenOSRS"
@@ -138,6 +139,15 @@ subprojects {
                 copy {
                     from("./build/libs/")
                     into("../release/")
+                }
+
+                val externalManagerDirectory: String = project.findProperty("externalManagerDirectory")?.toString() ?: System.getProperty("user.home") + "/.runelite/externalmanager"
+                val releaseToExternalModules: List<String> = project.findProperty("releaseToExternalmanager")?.toString()?.split(",") ?: emptyList()
+                if (releaseToExternalModules.contains(subprojectName) || releaseToExternalModules.contains("all")) {
+                    copy {
+                        from("./build/libs/")
+                        into(externalManagerDirectory)
+                    }
                 }
             }
         }


### PR DESCRIPTION
I'm updating the plugin development documentation, and would like to streamline the process of letting people copy plugins into their externalmanager folder.

This change lets people easily add some arguments to the build to do this task for them, and they won't have to edit any files.

Excerpt from documentation:

You can have Gradle automatically copy the plugin file to your externalmanager folder every time you build. To do so modify your `plugins [build]` configuration and add `-PreleaseToExternalmanager=all` to **Arguments**. Alternatively you can provide a comma-separated list of plugin names to copy.
