### PR TITLE
timers: bump ver to 0.0.15 for auto update

### DIFF
--- a/timers/timers.gradle.kts
+++ b/timers/timers.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.13"
+version = "0.0.15"
 
 project.extra["PluginName"] = "Timers"
 project.extra["PluginDescription"] = "Show various timers in an infobox"


### PR DESCRIPTION
0.0.14 is scuffed, someone reverted to 0.0.13 but that obv doesnt auto update, therefore the need for this