### PR TITLE
MenuEntrySwapper: Miscellania option fix

### DIFF
--- a/menuentryswapper/menuentryswapper.gradle.kts
+++ b/menuentryswapper/menuentryswapper.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.25"
+version = "0.0.26"
 
 project.extra["PluginName"] = "Menu Entry Swapper"
 project.extra["PluginDescription"] = "Change the default option that is displayed when hovering over objects"

--- a/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/menuentryswapper/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -831,7 +831,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 			menuManager.addPriorityEntry("Ungael").setPriority(10);
 			menuManager.addPriorityEntry("Pirate's Cove").setPriority(10);
 			menuManager.addPriorityEntry("Waterbirth Island").setPriority(10);
-			menuManager.addPriorityEntry("Miscellania").setPriority(10);
+			menuManager.addPriorityEntry("Miscellania", "Sailor").setPriority(10);
 			menuManager.addPriorityEntry("Island of Stone").setPriority(10);
 			menuManager.addPriorityEntry("Follow", "Elkoy").setPriority(10);
 			menuManager.addPriorityEntry("Transport").setPriority(10);


### PR DESCRIPTION
Add target so it won't force 'Miscellania' on Ring of Wealth/POH jewelry box if travel swaps are enabled.