### PR TITLE
idle notifier: friends and clan options

### DIFF
--- a/idlenotifier/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
+++ b/idlenotifier/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
@@ -262,10 +262,33 @@ public interface IdleNotifierConfig extends Config
 		name = "PKer Notifier",
 		description = "Notifies if an attackable player based on your level range appears on screen.",
 		position = 21,
-		section = "pvpSection",
-		warning = "This will not notify you if the player is in your cc or is online on your friends list."
+		section = "pvpSection"
 	)
 	default boolean notifyPkers()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			keyName = "pkersIgnoreFriends",
+			name = "Pker Notifier (ignore friends)",
+			description = "If Pker Notifier is turned on, do not notify when friends appear.",
+			position = 22,
+			section = "pvpSection"
+	)
+	default boolean notifyPkersIgnoreFriends()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			keyName = "pkersIgnoreClan",
+			name = "PKer Notifier (ignore clan members)",
+			description = "If Pker Notifier is turned on, do not notify when friends appear.",
+			position = 23,
+			section = "pvpSection"
+	)
+	default boolean notifyPkersIgnoreClan()
 	{
 		return false;
 	}
@@ -274,7 +297,7 @@ public interface IdleNotifierConfig extends Config
 		keyName = "resourceDoor",
 		name = "Resource Door Notifier",
 		description = "Notifies if the wilderness resource area door is opened",
-		position = 22,
+		position = 24,
 		section = "pvpSection"
 	)
 	default boolean notifyResourceDoor()

--- a/idlenotifier/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/idlenotifier/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -337,9 +337,14 @@ public class IdleNotifierPlugin extends Plugin
 	private void onPlayerSpawned(PlayerSpawned event)
 	{
 		final Player p = event.getPlayer();
+		boolean checkFriends = config.notifyPkersIgnoreFriends();
+		boolean checkClanChat = config.notifyPkersIgnoreClan();
+		boolean friendConditionalMet = client.isFriended(p.getName(), false) && checkFriends;
+		boolean clanChatConditionalMet = friendChatManager.isMember(p.getName()) && checkClanChat;
+
 		if (config.notifyPkers() && p != null && p != client.getLocalPlayer()
-			&& PvPUtil.isAttackable(client, p) && !client.isFriended(p.getName(), false)
-			&& !friendChatManager.isMember(p.getName()))
+			&& PvPUtil.isAttackable(client, p) && friendConditionalMet
+			&& clanChatConditionalMet)
 		{
 			String playerName = p.getName();
 			int combat = p.getCombatLevel();


### PR DESCRIPTION
Add GUI options to show players on friends list or players in cc.

Sometimes, user may want to add players to friends list to see when they are online and what world they are on.