### PR TITLE
playerindicators: remove friend check on clan relationship

### DIFF
--- a/playerindicators/playerindicators.gradle.kts
+++ b/playerindicators/playerindicators.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.8"
+version = "0.0.9"
 
 project.extra["PluginName"] = "Player Indicators"
 project.extra["PluginDescription"] = "Highlight players on-screen and/or on the minimap"

--- a/playerindicators/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
+++ b/playerindicators/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
@@ -60,7 +60,7 @@ public class PlayerIndicatorsService
 			&& client.isFriended(player.getName(), false)
 			&& plugin.getLocationHashMap().containsKey(PlayerIndicatorsPlugin.PlayerRelation.FRIEND));
 
-		clan = (player) -> (player.isFriendsChatMember() && !client.getLocalPlayer().equals(player) && !client.isFriended(player.getName(), false)
+		clan = (player) -> (player.isFriendsChatMember() && !client.getLocalPlayer().equals(player)
 			&& plugin.getLocationHashMap().containsKey(PlayerIndicatorsPlugin.PlayerRelation.CLAN));
 
 		team = (player) -> (Objects.requireNonNull(client.getLocalPlayer()).getTeam() != 0 && !player.isFriendsChatMember()


### PR DESCRIPTION
remove friend check on clan relationship

Clan members that were added as friends would not be given the clan relationship which means would not appear with the "hightlight clan" option. Friends highlight still takes priority if you have both clan + friends highlights turned on.