### PR TITLE
profiles: add checking for excess colons in notes, usernames and passwords

### DIFF
--- a/profiles/profiles.gradle.kts
+++ b/profiles/profiles.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.6"
+version = "0.0.7"
 
 project.extra["PluginName"] = "Account Switcher"
 project.extra["PluginDescription"] = "Allow for a allows you to easily switch between multiple OSRS Accounts"

--- a/profiles/src/main/java/net/runelite/client/plugins/profiles/ProfilePanel.java
+++ b/profiles/src/main/java/net/runelite/client/plugins/profiles/ProfilePanel.java
@@ -67,7 +67,7 @@ class ProfilePanel extends JPanel
 
 	ProfilePanel(final Client client, final String data, final ProfilesConfig config, final ProfilesPanel parent)
 	{
-		String[] parts = data.split(":");
+		String[] parts = data.split(":", 3);
 		this.loginText = parts[1];
 		if (parts.length == 3)
 		{

--- a/profiles/src/main/java/net/runelite/client/plugins/profiles/ProfilesPanel.java
+++ b/profiles/src/main/java/net/runelite/client/plugins/profiles/ProfilesPanel.java
@@ -276,6 +276,11 @@ class ProfilesPanel extends PluginPanel
 			{
 				return;
 			}
+			if (labelText.contains(":") || loginText.contains(":"))
+			{
+				JOptionPane.showMessageDialog(null, "You may not use colons in your label or login name", "Account Switcher", JOptionPane.ERROR_MESSAGE);
+				return;
+			}
 			String data;
 			if (profilesConfig.rememberPassword() && txtPasswordLogin.getPassword() != null)
 			{


### PR DESCRIPTION
This handles colons in passwords appropriately by limiting the split length to 3, it will be 2 if there is no password, and 3 if there is a password, however if the password contained a colon it would split further destroying the password contents into separate array elements. This new code keeps the full password in one array element.