### PR TITLE
camera: fix camera zoom limit

### DIFF
--- a/camera/camera.gradle.kts
+++ b/camera/camera.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.5"
+version = "0.0.6"
 
 project.extra["PluginName"] = "Camera"
 project.extra["PluginDescription"] = "Expands zoom limit, provides vertical camera, and remaps mouse input keys"

--- a/camera/src/main/java/net/runelite/client/plugins/camera/CameraPlugin.java
+++ b/camera/src/main/java/net/runelite/client/plugins/camera/CameraPlugin.java
@@ -179,13 +179,6 @@ public class CameraPlugin extends Plugin implements KeyListener, MouseListener
 	@Subscribe
 	private void onScriptCallbackEvent(ScriptCallbackEvent event)
 	{
-		if (client.getIndexScripts().isOverlayOutdated())
-		{
-			// if any cache overlay fails to load then assume at least one of the zoom scripts is outdated
-			// and prevent zoom extending entirely.
-			return;
-		}
-
 		int[] intStack = client.getIntStack();
 		int intStackSize = client.getIntStackSize();
 


### PR DESCRIPTION
This code block prevents camera zoom from working if other scripts are broken, which seems rather silly, As the script is easily updated.