### PR TITLE
revert: camera: fix camera zoom limit

### DIFF
--- a/camera/camera.gradle.kts
+++ b/camera/camera.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.6"
+version = "0.0.5"
 
 project.extra["PluginName"] = "Camera"
 project.extra["PluginDescription"] = "Expands zoom limit, provides vertical camera, and remaps mouse input keys"

--- a/camera/camera.gradle.kts
+++ b/camera/camera.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.5"
+version = "0.0.7"
 
 project.extra["PluginName"] = "Camera"
 project.extra["PluginDescription"] = "Expands zoom limit, provides vertical camera, and remaps mouse input keys"

--- a/camera/src/main/java/net/runelite/client/plugins/camera/CameraPlugin.java
+++ b/camera/src/main/java/net/runelite/client/plugins/camera/CameraPlugin.java
@@ -179,6 +179,13 @@ public class CameraPlugin extends Plugin implements KeyListener, MouseListener
 	@Subscribe
 	private void onScriptCallbackEvent(ScriptCallbackEvent event)
 	{
+		if (client.getIndexScripts().isOverlayOutdated())
+		{
+			// if any cache overlay fails to load then assume at least one of the zoom scripts is outdated
+			// and prevent zoom extending entirely.
+			return;
+		}
+
 		int[] intStack = client.getIntStack();
 		int intStackSize = client.getIntStackSize();
 


### PR DESCRIPTION
The camera script modifications are split across multiple rs2asm files, for the camera plugin to work properly they all have to be applied, I agree this isn't an ideal way of checking, but outside of a way to check specifically what scripts failed (which I can't be bothered to add) this will have to do. Without this some events fire, others don't, and the plugin decides to randomly zoom all over the place.