### PR TITLE
loottracker: never submit loot to rl api

### DIFF
--- a/loottracker/loottracker.gradle.kts
+++ b/loottracker/loottracker.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.28"
+version = "0.0.29"
 
 project.extra["PluginName"] = "Loottracker"
 project.extra["PluginDescription"] = "Tracks loot from monsters and minigames"

--- a/loottracker/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
+++ b/loottracker/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
@@ -85,11 +85,22 @@ public interface LootTrackerConfig extends Config
 	@ConfigItem(
 		keyName = "saveLoot",
 		name = "Submit loot tracker data",
-		description = "Submit loot tracker data"
+		description = "Submit loot tracker data",
+		hidden = true
 	)
 	default boolean saveLoot()
 	{
-		return true;
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "saveLoot",
+		name = "Submit loot tracker data",
+		description = "Submit loot tracker data",
+		hidden = true
+	)
+	default void saveLoot(boolean val)
+	{
 	}
 
 	@ConfigItem(

--- a/loottracker/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/loottracker/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -451,6 +451,9 @@ public class LootTrackerPlugin extends Plugin
 	@Override
 	protected void startUp()
 	{
+		// Never submit loot to the tracker, it'll always fail anyway.
+		config.saveLoot(false);
+
 		ignoredItems = Text.fromCSV(config.getIgnoredItems());
 		ignoredNPCs = Text.fromCSV(config.getIgnoredNPCs());
 		ignoredEvents = Text.fromCSV(config.getIgnoredEvents());


### PR DESCRIPTION
Should theoretically fix the url == null issue, we don't track loot using the RL API anyway.