### PR TITLE
playerindicators: fix minimum caller rank

### DIFF
--- a/playerindicators/playerindicators.gradle.kts
+++ b/playerindicators/playerindicators.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.0.9"
+version = "0.1.0"
 
 project.extra["PluginName"] = "Player Indicators"
 project.extra["PluginDescription"] = "Highlight players on-screen and/or on the minimap"

--- a/playerindicators/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/playerindicators/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -395,7 +395,7 @@ public class PlayerIndicatorsPlugin extends Plugin
 		{
 			for (FriendsChatMember clanMember : clanMemberManager.getMembers())
 			{
-				if (clanMember.getRank().getValue() > config.callerRank().getValue())
+				if (clanMember.getRank().getValue() >= config.callerRank().getValue())
 				{
 					callers.add(Text.standardize(clanMember.getName()));
 				}


### PR DESCRIPTION
It now shows all ranks including minimum, not only the ones higher than it